### PR TITLE
Start distutils for Python DFXML libraries

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,8 @@
+from distutils.core import setup
+setup(
+  name='dfxml',
+  version='1.0.1',
+  url='https://github.com/simsong/dfxml',
+#  scripts=['idifference.py','rdifference.py'],
+  py_modules=['dfxml','fiwalk']
+)


### PR DESCRIPTION
The discussion for this patch: How should dfxml.py and fiwalk.py be
installed, and loaded into calling scripts?  And, how should the
scripts in the dfxml project be distributed?

First, should dfxml and fiwalk be loaded with `import dfxml` or
`from dfxml import dfxml`?

Later, should the other scripts like idifference.py be installed with
Autotools, or distutils in a Python package called "dfxml"?

If you're fine with {dfxml,fiwalk}.py being installed directly to
`site-packages`, then you should just pull this patch in.

This patch starts distutils functionality by making something
installable in site-packages.

I left the 'scripts' argument in commented out, to show that it places
scripts where we might not want.  See the second snippet, installing to
./tmp2, below.

.../python$ python setup.py install --prefix=$PWD/tmp1
[snip]
.../python$ find tmp1
tmp1
tmp1/lib
tmp1/lib/python2.7
tmp1/lib/python2.7/site-packages
tmp1/lib/python2.7/site-packages/dfxml-1.0.1-py2.7.egg-info
tmp1/lib/python2.7/site-packages/dfxml.py
tmp1/lib/python2.7/site-packages/dfxml.pyc
tmp1/lib/python2.7/site-packages/fiwalk.py
tmp1/lib/python2.7/site-packages/fiwalk.pyc

It's from the next snippet that I suppose the autotools would be better
for listing installable scripts.

.../python$ python setup.py install --prefix=$PWD/tmp2
[snip]
.../python$ find tmp2
tmp2
tmp2/bin
tmp2/bin/idifference.py
tmp2/bin/rdifference.py
tmp2/lib
tmp2/lib/python2.7
tmp2/lib/python2.7/site-packages
tmp2/lib/python2.7/site-packages/dfxml-1.0.1-py2.7.egg-info
tmp2/lib/python2.7/site-packages/dfxml.py
tmp2/lib/python2.7/site-packages/dfxml.pyc
tmp2/lib/python2.7/site-packages/fiwalk.py
tmp2/lib/python2.7/site-packages/fiwalk.pyc
