### PR TITLE
Byte run fill fix

### DIFF
--- a/python/dfxml.py
+++ b/python/dfxml.py
@@ -211,6 +211,7 @@ class byte_run:
         self.img_offset = img_offset
         self.file_offset = file_offset
         self.len = len
+        self.fill = None
         self.sector_size = 512          # default
         self.hashdigest  = dict()       # 
 
@@ -257,10 +258,12 @@ class byte_run:
     def has_sector(self,s):
         if self.sector_size==0:
             raise ValueError("%s: sector_size cannot be 0" % (self))
+        if not self.fill == None:
+            return False
         try:
             return self.img_offset <= s * self.sector_size < self.img_offset+self.len
-        except (AttributeError, TypeError):
-            # Doesn't have necessary attributes or type to answer true.
+        except AttributeError:
+            # Doesn't have necessary attributes to answer true.
             # Usually this happens with runs of a constant value
             return False       
 

--- a/python/dfxml.py
+++ b/python/dfxml.py
@@ -211,7 +211,6 @@ class byte_run:
         self.img_offset = img_offset
         self.file_offset = file_offset
         self.len = len
-        self.fill = None
         self.sector_size = 512          # default
         self.hashdigest  = dict()       # 
 
@@ -258,7 +257,7 @@ class byte_run:
     def has_sector(self,s):
         if self.sector_size==0:
             raise ValueError("%s: sector_size cannot be 0" % (self))
-        if not self.fill == None:
+        if hasattr(self, 'fill') or hasattr(self, 'uncompressed_len'):
             return False
         try:
             return self.img_offset <= s * self.sector_size < self.img_offset+self.len

--- a/python/dfxml.py
+++ b/python/dfxml.py
@@ -259,8 +259,8 @@ class byte_run:
             raise ValueError("%s: sector_size cannot be 0" % (self))
         try:
             return self.img_offset <= s * self.sector_size < self.img_offset+self.len
-        except AttributeError:
-            # Doesn't have necessary attributes to answer true.
+        except (AttributeError, TypeError):
+            # Doesn't have necessary attributes or type to answer true.
             # Usually this happens with runs of a constant value
             return False       
 


### PR DESCRIPTION
Initializing the fill attribute to None. If fill has a value it doesn’t
have sectors associated with it on the disk.