### PR TITLE
Check for file being allocated on disk prior to returning sector used

### DIFF
--- a/python/dfxml.py
+++ b/python/dfxml.py
@@ -257,6 +257,9 @@ class byte_run:
     def has_sector(self,s):
         if self.sector_size==0:
             raise ValueError("%s: sector_size cannot be 0" % (self))
+        if self.img_offset is None:
+            # Sparse files don't have data allocated on disk
+            return False
         try:
             return self.img_offset <= s * self.sector_size < self.img_offset+self.len
         except AttributeError:

--- a/python/dfxml.py
+++ b/python/dfxml.py
@@ -257,7 +257,7 @@ class byte_run:
     def has_sector(self,s):
         if self.sector_size==0:
             raise ValueError("%s: sector_size cannot be 0" % (self))
-        if self.img_offset is None:
+        if self.img_offset is None or self.len is None:
             # Sparse files don't have data allocated on disk
             return False
         try:


### PR DESCRIPTION
Sparse files have byte_runs that are not allocated on disk. In any
case, if img_offset is None, has_sector is False by definition.