### PR TITLE
setup.py: Fix deployment of modules with pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ matrix:
         - cd python
       script:
         - pytest
+        - cd tests/test_venv
+        - make check
     - language: python
       python: 3.5
       before_script:
@@ -58,12 +60,16 @@ matrix:
         # Note py.test is in Python 3.5, but 3.6 onward it's pytest.
         #   c/o: https://stackoverflow.com/a/41262275
         - py.test
+        - cd tests/test_venv
+        - make check
     - language: python
       python: 3.7
       before_script:
         - cd python
       script:
         - pytest
+        - cd tests/test_venv
+        - make check
     - language: cpp
       os: linux
       before_script:

--- a/python/ChangeLog
+++ b/python/ChangeLog
@@ -1,5 +1,6 @@
 2019-07-05    <alexander.nelson@nist.gov>
 
+	* setup.py: Use setuptools.find_packages
 	* setup.py: Use setuptools instead of distutils
 	* setup.py: Add unit test for setup.py pip deployment
 	* __init__.py: Catch further commenting of _logger module-level object

--- a/python/ChangeLog
+++ b/python/ChangeLog
@@ -1,5 +1,6 @@
 2019-07-05    <alexander.nelson@nist.gov>
 
+	* setup.py: Add unit test for setup.py pip deployment
 	* __init__.py: Catch further commenting of _logger module-level object
 
 2019-03-14    <alexander.nelson@nist.gov>

--- a/python/ChangeLog
+++ b/python/ChangeLog
@@ -1,5 +1,6 @@
 2019-07-05    <alexander.nelson@nist.gov>
 
+	* setup.py: Use setuptools instead of distutils
 	* setup.py: Add unit test for setup.py pip deployment
 	* __init__.py: Catch further commenting of _logger module-level object
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,11 +13,12 @@
 #
 # We would appreciate acknowledgement if the software is used.
 
-from setuptools import setup
+from setuptools import setup, find_packages
 setup(
   name='dfxml',
   version='1.0.1',
   url='https://github.com/simsong/dfxml',
 #  scripts=['idifference.py','rdifference.py'],
+  packages=find_packages(),
   py_modules=['dfxml','fiwalk']
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,7 +13,7 @@
 #
 # We would appreciate acknowledgement if the software is used.
 
-from distutils.core import setup
+from setuptools import setup
 setup(
   name='dfxml',
   version='1.0.1',

--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,5 @@ setup(
   version='1.0.1',
   url='https://github.com/simsong/dfxml',
 #  scripts=['idifference.py','rdifference.py'],
-  packages=find_packages(),
-  py_modules=['dfxml','fiwalk']
+  packages=find_packages()
 )

--- a/python/tests/test_venv/.gitignore
+++ b/python/tests/test_venv/.gitignore
@@ -1,0 +1,2 @@
+.venv.done.log
+venv

--- a/python/tests/test_venv/Makefile
+++ b/python/tests/test_venv/Makefile
@@ -1,0 +1,47 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL = /bin/bash
+
+# The PYTHON variable is written to be provided primarily by a Travis virtual environment.  Local tests should provide their own python binary by calling 'make PYTHON=python3.7 [...]'
+PYTHON ?= $(shell which python 2>/dev/null || which python3 2>/dev/null || which python3.7 2>/dev/null || which python3.6 2>/dev/null)
+ifeq ($(PYTHON),)
+$(error PYTHON not defined)
+endif
+
+VIRTUALENV ?= $(shell which virtualenv 2>/dev/null || which virtualenv-3.7 2>/dev/null || which virtualenv-3.6 2>/dev/null)
+ifeq ($(VIRTUALENV),)
+$(error VIRTUALENV not defined)
+endif
+
+all: \
+  .venv.done.log
+
+.venv.done.log: \
+  ../../setup.py
+	rm -rf venv
+	$(VIRTUALENV) \
+	  --python=$(PYTHON) \
+	  venv
+	source venv/bin/activate \
+	  ; pip install ../..
+	touch $@
+
+check: \
+  .venv.done.log \
+  simple_read_dfxml.py
+	source venv/bin/activate \
+	  ; python simple_read_dfxml.py ../../../samples/difference_test_0.xml
+
+clean:
+	@rm -rf .venv.done.log venv

--- a/python/tests/test_venv/simple_read_dfxml.py
+++ b/python/tests/test_venv/simple_read_dfxml.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+"""
+This script confirms that the DFXML pip-managed packaging exposes the dfxml package and the objects.py module.
+"""
+
+import sys
+
+import dfxml
+import dfxml.objects
+
+def nop(x):
+    pass
+
+with open(sys.argv[1], "rb") as fh:
+    dfxml.read_dfxml(fh, callback=nop)
+
+for (event, obj) in dfxml.objects.iterparse(sys.argv[1]):
+    pass


### PR DESCRIPTION
I found that running `pip install .../dfxml/python` was reading
`setup.py`, but not installing module files.

This patch series adds a unit test to confirm that call to `pip` will
work, and then makes corrections to `setup.py` that enable export of the
modules under this repository's directory `/python/dfxml`.
