### PR TITLE
Use https to retrieve tarballs in CI workflow

### DIFF
--- a/etc/install_autotools.sh
+++ b/etc/install_autotools.sh
@@ -13,10 +13,10 @@ mkdir -p $build
 
 ##
 # Autoconf
-# http://ftpmirror.gnu.org/autoconf
+# https://ftpmirror.gnu.org/autoconf
 
 cd $build
-curl -OL http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
+curl -OL https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
 tar xzf autoconf-2.69.tar.gz
 cd autoconf-2.69
 ./configure --prefix=/usr/local
@@ -26,10 +26,10 @@ export PATH=$PATH:/usr/local/bin
 
 ##
 # Automake
-# http://ftpmirror.gnu.org/automake
+# https://ftpmirror.gnu.org/automake
 
 cd $build
-curl -OL http://ftpmirror.gnu.org/automake/automake-1.16.tar.gz
+curl -OL https://ftpmirror.gnu.org/automake/automake-1.16.tar.gz
 tar xzf automake-1.16.tar.gz
 cd automake-1.16
 ./configure --prefix=/usr/local
@@ -38,10 +38,10 @@ sudo make install
 
 ##
 # Libtool
-# http://ftpmirror.gnu.org/libtool
+# https://ftpmirror.gnu.org/libtool
 
 cd $build
-curl -OL http://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.gz
+curl -OL https://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.gz
 tar xzf libtool-2.4.6.tar.gz
 cd libtool-2.4.6
 ./configure --prefix=/usr/local


### PR DESCRIPTION
While looking through the Github Action, I saw a helper script to guarantee some Autotools are present.  I appreciate the script is for the Github Action, but it includes a practice we shouldn't encourage.

I saw the script builds and `sudo make install`s tarballs that are retrieved over HTTP.  I upgraded the protocol to `https` and re-enabled the Github Action in a private branch, and can confirm that the workflow's tests pass with this patch applied.  The commit re-enabling the Action is not part of this pull request.