### PR TITLE
Modify automake-build process to build dfxml as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ $ git checkout -b tmp  ; git checkout master ; git merge tmp ; git branch -d tmp
 ### Usage with the DFXML Schema
 The [DFXML schema](https://github.com/dfxml-working-group/dfxml_schema) is tracked here similarly to a Git submodule, but without using the Git submodule mechanism to avoid some operational deployment issues.  If you would like to check out the tracked schema version, run `make schema-init`.  It is only necessary to check this out if you are testing validation of DFXML content against the schema.
 
+### Building dfxml as a shared library
+To build dfxml as a shared library, run the following commands:
+
+```bash
+autoreconf -vif
+automake
+./configure
+make
+sudo make install
+```
+
+Note: If you are on a Linux machine ensure, that the packages specified in `src/requirements-ubuntu.txt` are installed. 
+
 Release Notes
 =============
 - 2018-07-22 @simsong Significant redesign of the Python library.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,18 +1,32 @@
 # (C) 2020 Simson L. Garfinkel
 # https://www.gnu.org/licenses/lgpl-3.0.en.html
 
-DFXML_SRC_DIR =
+DFXML_SRC_DIR = 
+ACLOCAL_AMFLAGS = -I m4
+
 include Makefile.defs
 
+# Build dfxml as a library
+lib_LTLIBRARIES = libdfxml.la
+libdfxml_la_SOURCES = $(DFXML_WRITER) $(DFXML_READER)
+libdfxml_la_LDFLAGS = -version-info 0:0:0
+include_HEADERS  = dfxml_reader.h dfxml_writer.h
+
+# Build demo programs
 bin_PROGRAMS = dfxml_demo iblkfind
-dfxml_demo_SOURCES = dfxml_demo.cpp cpuid.h $(DFXML_READER)
-iblkfind_SOURCES = iblkfind.cpp $(DFXML_READER)
+dfxml_demo_SOURCES = dfxml_demo.cpp cpuid.h
+dfxml_demo_LDADD = ./libdfxml.la
+
+iblkfind_SOURCES = iblkfind.cpp
+iblkfind_LDADD = ./libdfxml.la
+
 EXTRA_DIST = README.md 
 
 check_PROGRAMS = testapp_catch2
 TESTS = $(check_PROGRAMS)
 
-testapp_catch2_SOURCES = testapp_catch2.cpp tests/catch.hpp $(DFXML_WRITER) $(DFXML_READER)
+testapp_catch2_SOURCES = testapp_catch2.cpp tests/catch.hpp
+testapp_catch2_LDADD = ./libdfxml.la
 
 # https://stackoverflow.com/questions/15013672/use-autotools-with-readme-md
 # We provide README.md instead of README. This prevents autotools from complaining.

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -8,7 +8,7 @@
 # This file is public domain
 #
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 AC_INIT([DFXML],[1.0.1],[bugs@digitalcorpora.org])
 AC_CONFIG_MACRO_DIR(m4)
 m4_include([m4/ax_cxx_compile_stdcxx.m4])
@@ -18,6 +18,10 @@ AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE
 
+# Initialize libtool support
+LT_PREREQ([2.4.6])
+LT_INIT([shared])
+LT_LANG([C++])
 
 # Programs we will be using
 AC_PROG_CC


### PR DESCRIPTION
Dear Simson, 

this PR modifies the build process in a way so that the dfxml-C++-codebase is build as a library, which makes the build process a bit tidier in my opinion. Furthermor, this prepares a system-wide installation of dfxml, which might be added in the future.  

Please note, that I decreased the required AC-version, so that dfxml builds on Debian Bullseye (current testing, soon stable), what you might omit. 

Thank you already in advance for considering a merge of this PR. I hope it does not interfere with code (BE,...), that builds up on dfxml.

Best regards
    Jan 