### PR TITLE
Fixes undefined function va_end(...)

### DIFF
--- a/src/dfxml_writer.h
+++ b/src/dfxml_writer.h
@@ -23,6 +23,7 @@
 #include <stack>
 #include <string>
 #include <stdexcept>
+#include <stdarg.h>
 
 #include <sys/time.h>
 


### PR DESCRIPTION
Dear Simson, 

I tested the newly added header-only library `dfxml_writer.h` and noticed an error, which stated that the function va_end(...) is
undefined. This is solved by including `<stdarg.h>` (See http://www.cplusplus.com/reference/cstdarg/va_end/).

Thanks already in advance for reviewing! 
 
Best regards
   Jan 